### PR TITLE
feat: improve beian display with labels, security attrs and custom HTML area

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -345,6 +345,11 @@ spec:
           label: 公安联网备案跳转链接
           value: https://beian.mps.gov.cn/#/query/webSearch
 
+        - $formkit: textarea
+          name: div
+          label: 悬挂区域
+          help: "自定义备案区域的HTML内容"
+
     - group: development
       label: 开发设置
       formSchema:

--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -27,29 +27,41 @@
         href="https://github.com/jiewenhuang/halo-theme-fuwari"
         >Theme-Fuwari</a
       >
-      <br />
-      <div class="">
-        <a
-          th:if="${not #strings.isEmpty(theme.config.beian.icp_text)}"
-          class="hover:underline"
-          target="_blank"
-          href="https://beian.miit.gov.cn/"
-          th:href="${theme.config.beian.icp_link}"
-          th:text="${theme.config.beian.icp_text}"
-        ></a>
+      <div
+        class="mt-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-black/50 transition dark:text-white/50"
+        th:if="${not #strings.isEmpty(theme.config.beian.icp_text)} or ${not #strings.isEmpty(theme.config.beian.gongan_text)}"
+      >
+        <th:block th:if="${not #strings.isEmpty(theme.config.beian.icp_text)}">
+          <a
+            class="hover:underline"
+            target="_blank"
+            rel="noopener"
+            th:href="${#strings.isEmpty(theme.config.beian.icp_link) ? 'https://beian.miit.gov.cn/' : theme.config.beian.icp_link}"
+            th:text="|ICP备案号：${theme.config.beian.icp_text}|"
+          >ICP备案号</a>
+        </th:block>
         <th:block th:if="${not #strings.isEmpty(theme.config.beian.gongan_text)}">
-          <p class="flex items-center justify-center gap-1">
-            <img th:src="@{/assets/images/gongan_beian.png}" class="size-4" alt="gongan_beian" />
-            <a
-              href="https://beian.mps.gov.cn/#/query/webSearch"
-              class="hover:underline"
-              target="_blank"
-              th:href="${theme.config.beian.gongan_link}"
-              th:text="${theme.config.beian.gongan_text}"
-            ></a>
-          </p>
+          <a
+            class="inline-flex items-center gap-1 hover:underline"
+            target="_blank"
+            rel="noopener"
+            th:href="${#strings.isEmpty(theme.config.beian.gongan_link) ? 'https://beian.mps.gov.cn/#/query/webSearch' : theme.config.beian.gongan_link}"
+          >
+            <img
+              th:src="@{/assets/images/gongan_beian.png}"
+              alt="公安备案"
+              class="size-4 opacity-80 transition dark:opacity-90"
+              loading="lazy"
+            />
+            <span th:text="|公安备案：${theme.config.beian.gongan_text}|">公安备案</span>
+          </a>
         </th:block>
       </div>
+      <div
+        th:if="${not #strings.isEmpty(theme.config.beian.div)}"
+        th:utext="${theme.config.beian.div}"
+        class="mt-2 flex items-center justify-center"
+      ></div>
     </div>
   </div>
   <halo:footer />


### PR DESCRIPTION
## Summary

改进备案区域的显示效果和功能：

- 给 ICP 和公安备案添加中文前缀标签（`ICP备案号：` / `公安备案：`），更符合国内用户习惯
- 添加 `rel="noopener"` 安全属性和 `loading="lazy"` 图片懒加载
- 链接字段为空时自动使用默认备案查询链接，避免空链接
- 新增「悬挂区域」设置项（`textarea`），支持自定义 HTML 内容
- 改进深色模式下备案区域的文字可读性

## Changes

- `settings.yaml`: 在 `beian` 组末尾新增 `div`（悬挂区域）字段
- `templates/modules/footer.html`: 改进备案区域的 HTML 结构和样式

## Test plan

- [ ] 在 Halo 控制台 → 外观 → 主题设置 → 备案设置 中填写 ICP 备案号和公安备案号，确认前端正确显示
- [ ] 确认不填写备案号时，备案区域不显示
- [ ] 确认「悬挂区域」填写自定义 HTML 后正确渲染
- [ ] 确认深色模式下备案区域文字可读
