### PR TITLE
fix: remove backticks for inline code

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -45,6 +45,11 @@
   @apply rounded-md bg-(--inline-code-bg) px-1.5 py-0.5 text-(--inline-code-color);
 }
 
+.custom-md code::before,
+.custom-md code::after {
+  content: none;
+}
+
 .custom-md pre {
   @apply rounded-xl bg-(--codeblock-bg) text-white;
 }


### PR DESCRIPTION
<img width="111" height="44" alt="图片" src="https://github.com/user-attachments/assets/9ed1c2c8-3b40-4b17-b0ed-fa565a38a065" />
<img width="70" height="47" alt="图片" src="https://github.com/user-attachments/assets/05fdc40a-f89a-4bd0-8ce6-7b6687c798d4" />

应该不是有意为之

fuwari 原版也没有