### PR TITLE
feat: 新增萌备案（萌ICP）支持

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -337,4 +337,4 @@ spec:
         - $formkit: text
           name: moe_link
           label: 萌ICP备案跳转链接
-          value: https://icp.gov.moe/?keyword=20250059
+          help: 萌备案跳转链接，如：https://icp.gov.moe/?keyword=20250059

--- a/settings.yaml
+++ b/settings.yaml
@@ -329,3 +329,12 @@ spec:
           name: gongan_link
           label: 公安联网备案跳转链接
           value: https://beian.mps.gov.cn/#/query/webSearch
+
+        - $formkit: text
+          name: moe_text
+          label: 萌ICP备案号
+          help: 萌备案号，如：萌ICP备20250059号
+        - $formkit: text
+          name: moe_link
+          label: 萌ICP备案跳转链接
+          value: https://icp.gov.moe/?keyword=20250059

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -51,6 +51,16 @@ const currentYear = new Date().getFullYear();
       target="_blank"
       th:text="${theme.config.beian.gongan_text}"></a>
   </div>
+  <div
+    class="mt-1"
+    th:if="${not #strings.isEmpty(theme.config.beian.moe_text)}"
+  >
+    <a
+      class="link font-medium text-(--primary)"
+      th:href="${theme.config.beian.moe_link}"
+      target="_blank"
+      th:text="${theme.config.beian.moe_text}"></a>
+  </div>
   <div class="mt-2">
     <span th:text="#{footer.poweredBy}">Powered by</span>
     <a

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -53,7 +53,7 @@ const currentYear = new Date().getFullYear();
   </div>
   <div
     class="mt-1"
-    th:if="${not #strings.isEmpty(theme.config.beian.moe_text)}"
+    th:if="${not #strings.isEmpty(theme.config.beian.moe_text) and not #strings.isEmpty(theme.config.beian.moe_link)}"
   >
     <a
       class="link font-medium text-(--primary)"

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -110,6 +110,8 @@ export interface Beian {
   icp_link: string;
   gongan_text: string;
   icp_text: string;
+  moe_text: string;
+  moe_link: string;
 }
 
 export interface Development {


### PR DESCRIPTION
## 新增功能

在页脚 ICP 备案 / 公安备案下方增加萌备案（萌ICP）链接显示，可通过主题设置自定义文字和链接。

## 使用方式

主题设置 → 备案设置，新增两个字段：
- **萌ICP备案号**：如 `萌ICP备20250059号`
- **萌ICP备案跳转链接**：如 `https://icp.gov.moe/?keyword=20250059`

填入后保存，页脚即显示萌备案链接。留空则不显示。

## 修改文件

- `src/types/config.ts` — Beian 接口增加 `moe_text` / `moe_link` 字段
- `src/components/Footer.astro` — 公安备案下方渲染萌备案链接，复用现有样式
- `settings.yaml` — 备案设置表单新增萌备案两个输入项